### PR TITLE
fix: add overscroll-behavior-x to fix double finger sliding in chrome.

### DIFF
--- a/packages/client/src/styles/main.css
+++ b/packages/client/src/styles/main.css
@@ -4,6 +4,7 @@ body,
   height: 100%;
   margin: 0;
   padding: 0;
+  overscroll-behavior-x: none;
 }
 
 html.dark {


### PR DESCRIPTION
add overscroll-behavior-x to fix double finger sliding in chrome.

添加 overscroll-behavior-x 来解决在chrome中双指左右滑动切换路由时，monaco-editor中代码无法正常滚动问题。